### PR TITLE
Feed manager keeps all entries

### DIFF
--- a/aio_geojson_geonetnz_volcano/feed_manager.py
+++ b/aio_geojson_geonetnz_volcano/feed_manager.py
@@ -1,8 +1,12 @@
 """Feed Manager for GeoNet NZ Volcanic Alert Level feed."""
+import logging
+
 from aio_geojson_client.feed_manager import FeedManagerBase
 from aiohttp import ClientSession
 
 from .feed import GeonetnzVolcanoFeed
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class GeonetnzVolcanoFeedManager(FeedManagerBase):
@@ -18,3 +22,16 @@ class GeonetnzVolcanoFeedManager(FeedManagerBase):
             filter_radius=filter_radius)
         super().__init__(feed, generate_callback, update_callback,
                          remove_callback, status_callback)
+
+    async def _store_feed_entries(self, status, feed_entries):
+        """Keep a copy of all feed entries for future lookups."""
+        if feed_entries:
+            external_ids = {entry.external_id: entry
+                            for entry in feed_entries}
+            # Override existing entries.
+            self.feed_entries.update(external_ids)
+
+    async def _update_feed_remove_entries(self, feed_external_ids):
+        """Do not remove entities."""
+        _LOGGER.debug("Not removing entries %s", feed_external_ids)
+        return 0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ DESCRIPTION = "An async GeoJSON client library for GeoNet NZ Volcanic Alert Leve
 URL = "https://github.com/exxamalte/python-aio-geojson-geonetnz-volcano"
 
 REQUIRES = [
-    'aio_geojson_client>=0.7',
+    'aio_geojson_client>=0.9',
     'aiohttp>=3.5.4',
     'pytz>=2019.01',
 ]

--- a/tests/fixtures/val-3.json
+++ b/tests/fixtures/val-3.json
@@ -1,0 +1,56 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          175.896,
+          -38.784
+        ]
+      },
+      "properties": {
+        "volcanoID": "volcano1",
+        "volcanoTitle": "Volcano 1",
+        "level": 0,
+        "activity": "No volcanic unrest.",
+        "hazards": "Volcanic environment hazards."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          175.641727,
+          -39.133318
+        ]
+      },
+      "properties": {
+        "volcanoID": "volcano2",
+        "volcanoTitle": "Volcano 2 UPDATED",
+        "level": 0,
+        "activity": "No volcanic unrest.",
+        "hazards": "Volcanic environment hazards."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          177.183,
+          -37.521
+        ]
+      },
+      "properties": {
+        "volcanoID": "volcano4",
+        "volcanoTitle": "Volcano 4",
+        "level": 2,
+        "activity": "Minor volcanic unrest.",
+        "hazards": "Volcanic unrest hazards."
+      }
+    }
+  ]
+}

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py36, py37, py38, cov, cov_local
 [testenv]
 deps=
     pytest
+    asynctest
     aresponses
     mock
 commands=pytest
@@ -12,6 +13,7 @@ commands=pytest
 deps=
     pytest
     pytest-cov
+    asynctest
     aresponses
     mock
 commands=
@@ -22,6 +24,7 @@ basepython=python3.7
 deps=
     pytest
     pytest-cov
+    asynctest
     aresponses
     mock
 commands=


### PR DESCRIPTION
...instead of removing them if the feed update is empty or fails intermittently.